### PR TITLE
update additional property fields for kitem apps

### DIFF
--- a/dsms/knowledge/properties/apps.py
+++ b/dsms/knowledge/properties/apps.py
@@ -13,11 +13,11 @@ if TYPE_CHECKING:
 class AdditionalProperties(BaseModel):
     """Additional properties of"""
 
-    triggeredUponUpload: bool = Field(
+    triggerUponUpload: bool = Field(
         False,
         description="Whether the app should be triggered when a file is uploaded",
     )
-    triggeredUponUploadFileExtensions: Optional[list[str]] = Field(
+    triggerUponUploadFileExtensions: Optional[list[str]] = Field(
         None,
         description="File extensions for which the upload shall be triggered.",
     )


### PR DESCRIPTION
There are small mismatches in the field names for additional properties of the kitem apps:


dsms-sdk ( datamodel : AdditionalProperties ) | Frontend ( no data model for additional_properties in knowledge service )
-- | --
triggeredUponUpload | triggerUponUpload
triggeredUponUploadFileExtensions | triggerUponUploadFileExtensions

This PR fixes this problem.