### PR TITLE
Env/sdk parameters

### DIFF
--- a/docs/dsms_sdk/tutorials/6_apps.ipynb
+++ b/docs/dsms_sdk/tutorials/6_apps.ipynb
@@ -270,7 +270,15 @@
     "appspec = AppConfig(\n",
     "    name=configname,\n",
     "    specification=specification,  # this can also be a file path to a yaml file instead of a dict\n",
+    "    use_sdk=True,\n",
     ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please note that the `use_sdk` is important here, since the pipeline needs to be aware of the settings of our platform and our current SDK-session."
    ]
   },
   {
@@ -798,7 +806,7 @@
    "source": [
     "We are able to run the app on demand, not being triggered automatically during the upload of an attachment every time. For this purpose, we just need to refer to the name of the app we assigned during the KItem creation ( here it is simply `data2rdf`).\n",
     "\n",
-    "Additionally, we need to tell the `attachment_name` and hand over the access token and host url to the app by explicitly setting `set_token` and `set_host_url` to `True`.\n",
+    "Additionally, we need to tell the `attachment_name` and hand over the access token and host url to the app by explicitly setting `use_sdk` to `True`. This is basically telling the SDK that the app is using the SDK also internally and that the app should receive its parameters from the current SDK session.\n",
     "\n",
     "The app is running synchronously, hence the `job` is created when the pipeline run finished."
    ]
@@ -811,8 +819,7 @@
    "source": [
     "job = item.kitem_apps.by_title[\"data2rdf\"].run(\n",
     "    attachment_name=item.attachments[0].name,\n",
-    "    set_token=True,\n",
-    "    set_host_url=True\n",
+    "    use_sdk=True\n",
     ")"
    ]
   },
@@ -882,8 +889,7 @@
    "source": [
     "job = item.kitem_apps.by_title[\"data2rdf\"].run(\n",
     "    attachment_name=item.attachments[0].name,\n",
-    "    set_token=True,\n",
-    "    set_host_url=True,\n",
+    "    use_sdk=True,\n",
     "    wait=False,\n",
     ")"
    ]

--- a/dsms/apps/config.py
+++ b/dsms/apps/config.py
@@ -40,6 +40,14 @@ class AppConfig(BaseModel):
         description="File path for YAML Specification of the app",
     )
 
+    use_sdk: bool = Field(
+        False,
+        description="""Whether the app is using the SDK internally.
+        This will pass the parameters like `request_timeout`, `pink_dsms`,
+        `host_url`, `ssl_verify`, `encoding` and `kitem_repo` to the
+        config of the app. The `token` will be set during runtime of the app.""",
+    )
+
     model_config = ConfigDict(
         extra="forbid",
         validate_assignment=True,
@@ -156,6 +164,14 @@ class AppConfig(BaseModel):
             and self.name not in self.context.buffers.updated
         ):
             self.context.buffers.updated.update({self.name: self})
+        if self.use_sdk:
+            parameters = self.specification["spec"]["arguments"]["parameters"]
+            parameters["request_timeout"] = self.dsms.config.request_timeout
+            parameters["ping"] = self.dsms.config.ping_dsms
+            parameters["host_url"] = str(self.dsms.config.host_url)
+            parameters["verify_ssl"] = self.dsms.config.ssl_verify
+            parameters["kitem_repo"] = self.dsms.config.kitem_repo
+            parameters["encoding"] = self.dsms.config.encoding
         return self
 
     @property

--- a/dsms/apps/config.py
+++ b/dsms/apps/config.py
@@ -165,13 +165,14 @@ class AppConfig(BaseModel):
         ):
             self.context.buffers.updated.update({self.name: self})
         if self.use_sdk:
-            parameters = self.specification["spec"]["arguments"]["parameters"]
-            parameters["request_timeout"] = self.dsms.config.request_timeout
-            parameters["ping"] = self.dsms.config.ping_dsms
-            parameters["host_url"] = str(self.dsms.config.host_url)
-            parameters["verify_ssl"] = self.dsms.config.ssl_verify
-            parameters["kitem_repo"] = self.dsms.config.kitem_repo
-            parameters["encoding"] = self.dsms.config.encoding
+            self.specification["spec"]["arguments"]["parameters"] += [
+                {"request_timeout": self.dsms.config.request_timeout},
+                {"ping": self.dsms.config.ping_dsms},
+                {"host_url": str(self.dsms.config.host_url)},
+                {"verify_ssl": self.dsms.config.ssl_verify},
+                {"kitem_repo": self.dsms.config.kitem_repo},
+                {"encoding": self.dsms.config.encoding},
+            ]
         return self
 
     @property

--- a/dsms/knowledge/properties/apps.py
+++ b/dsms/knowledge/properties/apps.py
@@ -90,8 +90,7 @@ class App(KItemProperty):
     def run(
         self,
         wait=True,
-        set_token: bool = False,
-        set_host_url: bool = False,
+        use_sdk=False,
         **kwargs,
     ) -> None:
         """Run application.
@@ -101,20 +100,20 @@ class App(KItemProperty):
                 (not in the background), but the object should wait until the job finished.
                 Warning: this may lead to a request timeout for long running jobs!
                     Job details may not be associated anymore when this occurs.
-            token (bool, optional): Whether the job also should receive the access
-                 token as paramter.If `True`, the JWT will be set as parameter with
-                 the name ´access_token`.
+            use_sdk (bool, optional): Whether the job is using the SDK internally
+                and hence should receive parameters from the current the SDK session.
+                If set to True, the `token`, `host_url`, `ping_dsms`, `verify_ssl`,
+                `request_timeout`, `encoding` and `kitem_repo` will be set as parameters.
+                Defaults to False.
             **kwargs (Any, optional): Additional arguments to be passed to the workflow.
                 KItem ID is passed automatically
 
         """
         kwargs["kitem_id"] = str(self.id)
-        if set_token:
+        if use_sdk:
             kwargs[
                 "access_token"
             ] = self.context.dsms.config.token.get_secret_value()
-        if set_host_url:
-            kwargs["host_url"] = str(self.context.dsms.config.host_url)
 
         response = _perform_request(
             f"api/knowledge/apps/argo/job/{self.executable}",

--- a/examples/tutorials/6_apps.ipynb
+++ b/examples/tutorials/6_apps.ipynb
@@ -264,7 +264,15 @@
     "appspec = AppConfig(\n",
     "    name=configname,\n",
     "    specification=specification,  # this can also be a file path to a yaml file instead of a dict\n",
+    "    use_sdk=True,\n",
     ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please note that the `use_sdk` is important here, since the pipeline needs to be aware of the settings of our platform and our current SDK-session."
    ]
   },
   {
@@ -792,7 +800,7 @@
    "source": [
     "We are able to run the app on demand, not being triggered automatically during the upload of an attachment every time. For this purpose, we just need to refer to the name of the app we assigned during the KItem creation ( here it is simply `data2rdf`).\n",
     "\n",
-    "Additionally, we need to tell the `attachment_name` and hand over the access token and host url to the app by explicitly setting `set_token` and `set_host_url` to `True`.\n",
+    "Additionally, we need to tell the `attachment_name` and hand over the access token and host url to the app by explicitly setting `use_sdk` to `True`. This is basically telling the SDK that the app is using the SDK also internally and that the app should receive its parameters from the current SDK session.\n",
     "\n",
     "The app is running synchronously, hence the `job` is created when the pipeline run finished."
    ]
@@ -805,8 +813,7 @@
    "source": [
     "job = item.kitem_apps.by_title[\"data2rdf\"].run(\n",
     "    attachment_name=item.attachments[0].name,\n",
-    "    set_token=True,\n",
-    "    set_host_url=True\n",
+    "    use_sdk=True\n",
     ")"
    ]
   },
@@ -876,8 +883,7 @@
    "source": [
     "job = item.kitem_apps.by_title[\"data2rdf\"].run(\n",
     "    attachment_name=item.attachments[0].name,\n",
-    "    set_token=True,\n",
-    "    set_host_url=True,\n",
+    "    use_sdk=True,\n",
     "    wait=False,\n",
     ")"
    ]


### PR DESCRIPTION
In order to operate fully with potentials apps and pipelines using the SDK internall, the SDK needs to pass its own parameters like `host_url`, `ssl_verify`, etc. to the appconfig or the job launch itself.