### PR TITLE
v3.0.2

### DIFF
--- a/dsms/core/configuration.py
+++ b/dsms/core/configuration.py
@@ -74,6 +74,12 @@ class Configuration(BaseSettings):
         description="JWT bearer token for connecting to the DSMS instance",
     )
 
+    reauthenticate: bool = Field(
+        True,
+        description="""Whether to reauthenticate with username and password
+        when the token is expired.""",
+    )
+
     ping_dsms: bool = Field(
         True, description="Check whether the host is a DSMS instance or not."
     )

--- a/dsms/core/configuration.py
+++ b/dsms/core/configuration.py
@@ -78,6 +78,13 @@ class Configuration(BaseSettings):
         True, description="Check whether the host is a DSMS instance or not."
     )
 
+    fetch_ktypes_automatically: bool = Field(
+        True,
+        description="""Whether the KTypes of the DSMS should be fetched automatically
+        when the session is started. They will be fetched if requested and cached
+        in memory.""",
+    )
+
     individual_slugs: bool = Field(
         True,
         description="""When set to `True`, the slugs of the KItems will receive the

--- a/dsms/core/configuration.py
+++ b/dsms/core/configuration.py
@@ -76,7 +76,7 @@ class Configuration(BaseSettings):
 
     enable_auto_reauth: bool = Field(
         True,
-        description="""Whether to reauthenticate with username and password
+        description="""Whether to automatically reauthenticate with username and password
         when the token is expired.""",
     )
 

--- a/dsms/core/configuration.py
+++ b/dsms/core/configuration.py
@@ -74,7 +74,7 @@ class Configuration(BaseSettings):
         description="JWT bearer token for connecting to the DSMS instance",
     )
 
-    reauthenticate: bool = Field(
+    enable_auto_reauth: bool = Field(
         True,
         description="""Whether to reauthenticate with username and password
         when the token is expired.""",
@@ -84,14 +84,14 @@ class Configuration(BaseSettings):
         True, description="Check whether the host is a DSMS instance or not."
     )
 
-    ktypes_on_startup: bool = Field(
+    auto_fetch_ktypes: bool = Field(
         True,
         description="""Whether the KTypes of the DSMS should be fetched automatically
         when the session is started. They will be fetched if requested and cached
         in memory.""",
     )
 
-    refetch_ktypes: bool = Field(
+    always_refetch_ktypes: bool = Field(
         False,
         description="""Whether the KTypes of the DSMS should be refetched
         every time used in the SDK. This can be helpful if the SDK is integrated

--- a/dsms/core/configuration.py
+++ b/dsms/core/configuration.py
@@ -84,11 +84,19 @@ class Configuration(BaseSettings):
         True, description="Check whether the host is a DSMS instance or not."
     )
 
-    fetch_ktypes_automatically: bool = Field(
+    ktypes_on_startup: bool = Field(
         True,
         description="""Whether the KTypes of the DSMS should be fetched automatically
         when the session is started. They will be fetched if requested and cached
         in memory.""",
+    )
+
+    refetch_ktypes: bool = Field(
+        False,
+        description="""Whether the KTypes of the DSMS should be refetched
+        every time used in the SDK. This can be helpful if the SDK is integrated
+        in a service and the KTypes are updated.
+        WARNING: This might lead to performance issues.""",
     )
 
     individual_slugs: bool = Field(

--- a/dsms/core/dsms.py
+++ b/dsms/core/dsms.py
@@ -98,7 +98,8 @@ class DSMS:
             )
 
         self._sparql_interface = SparqlInterface(self)
-        self.ktypes = _get_remote_ktypes()
+        if self.config.fetch_ktypes_automatically:
+            self.ktypes = _get_remote_ktypes()
 
     def __getitem__(self, key: str) -> "KItem":
         """Get KItem from remote DSMS instance."""
@@ -151,6 +152,8 @@ class DSMS:
     @property
     def ktypes(self) -> "Enum":
         """Getter for the Enum of the KTypes defined in the DSMS instance."""
+        if self._ktypes is None:
+            self._ktypes = _get_remote_ktypes()
         return self._ktypes
 
     @ktypes.setter

--- a/dsms/core/dsms.py
+++ b/dsms/core/dsms.py
@@ -98,7 +98,7 @@ class DSMS:
             )
 
         self._sparql_interface = SparqlInterface(self)
-        if self.config.fetch_ktypes_automatically:
+        if self.config.ktypes_on_startup:
             self.ktypes = _get_remote_ktypes()
 
     def __getitem__(self, key: str) -> "KItem":
@@ -152,7 +152,7 @@ class DSMS:
     @property
     def ktypes(self) -> "Enum":
         """Getter for the Enum of the KTypes defined in the DSMS instance."""
-        if self._ktypes is None:
+        if self._ktypes is None or self.config.refetch_ktypes:
             self._ktypes = _get_remote_ktypes()
         return self._ktypes
 

--- a/dsms/core/dsms.py
+++ b/dsms/core/dsms.py
@@ -98,7 +98,7 @@ class DSMS:
             )
 
         self._sparql_interface = SparqlInterface(self)
-        if self.config.ktypes_on_startup:
+        if self.config.auto_fetch_ktypes:
             self.ktypes = _get_remote_ktypes()
 
     def __getitem__(self, key: str) -> "KItem":
@@ -152,7 +152,7 @@ class DSMS:
     @property
     def ktypes(self) -> "Enum":
         """Getter for the Enum of the KTypes defined in the DSMS instance."""
-        if self._ktypes is None or self.config.refetch_ktypes:
+        if self._ktypes is None or self.config.always_refetch_ktypes:
             self._ktypes = _get_remote_ktypes()
         return self._ktypes
 

--- a/dsms/core/utils.py
+++ b/dsms/core/utils.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin
 from uuid import UUID
 
 import requests
+from pydantic import SecretStr
 from requests import Response
 
 from dsms.core.logging import handler  # isort:skip
@@ -39,7 +40,9 @@ def _ping_dsms():
     return _perform_request("api/knowledge/docs", "get")
 
 
-def _perform_request(route: str, method: str, **kwargs: "Any") -> Response:
+def _perform_request(
+    route: str, method: str, retry=True, headers=None, **kwargs: "Any"
+) -> Response:
     """Perform a general request for a certain route and with a certain method.
     Kwargs are general arguments which can be passed to the `requests.request`-function.
     """
@@ -49,7 +52,7 @@ def _perform_request(route: str, method: str, **kwargs: "Any") -> Response:
     response = requests.request(
         method,
         url=urljoin(str(dsms.config.host_url), route),
-        headers=dsms.headers,
+        headers=headers or dsms.headers,
         timeout=dsms.config.request_timeout,
         verify=dsms.config.ssl_verify,
         **kwargs,
@@ -61,6 +64,34 @@ def _perform_request(route: str, method: str, **kwargs: "Any") -> Response:
         debug_text = response.text
     logger.debug("Received the follow response from route `%s`:", route)
     logger.debug(debug_text)
+    if response.status_code == 401 and dsms.config.reauthenticate and retry:
+        if dsms.config.username and dsms.config.password:
+            username = dsms.config.username.get_secret_value()
+            passwd = dsms.config.password.get_secret_value()
+            authorization = f"Basic {username}:{passwd}"
+            reauth = _perform_request(
+                "api/users/token",
+                "get",
+                retry=False,
+                headers={"Authorization": authorization},
+            )
+            if not reauth.ok:
+                raise RuntimeError(f"Reauthentication failed: {reauth.text}")
+            logger.debug("Reauthentication successful.")
+            token = reauth.json().get("token")
+            if "Bearer " not in token:
+                dsms.config.token = SecretStr(f"Bearer {token}")
+            else:
+                dsms.config.token = SecretStr(token)
+            response = _perform_request(
+                route, method, retry=False, headers=None, **kwargs
+            )
+        else:
+            logger.debug("No credentials found for reauthentication.")
+    else:
+        logger.debug(
+            "Reauthentication skipped. Either not needed or not enabled."
+        )
     return response
 
 

--- a/dsms/core/utils.py
+++ b/dsms/core/utils.py
@@ -64,7 +64,11 @@ def _perform_request(
         debug_text = response.text
     logger.debug("Received the follow response from route `%s`:", route)
     logger.debug(debug_text)
-    if response.status_code == 401 and dsms.config.reauthenticate and retry:
+    if (
+        response.status_code == 401
+        and dsms.config.enable_auto_reauth
+        and retry
+    ):
         if dsms.config.username and dsms.config.password:
             username = dsms.config.username.get_secret_value()
             passwd = dsms.config.password.get_secret_value()

--- a/dsms/knowledge/utils.py
+++ b/dsms/knowledge/utils.py
@@ -762,8 +762,6 @@ def _slug_is_available(ktype_id: str, value: str) -> bool:
     response = _perform_request(
         f"api/knowledge/kitems/{ktype_id}/{value}", "head"
     )
-    if response.status_code == 401:
-        raise RuntimeError("The access token has expired")
     return response.status_code == 404
 
 


### PR DESCRIPTION
In this PR we implemented:

* **Reauthentication**: when the username and password is provided, the access token is automatically recreated if the old one expires. The DSMS-object hence does not need to be re-initialized and the session hence does not need to be re-started.
* **Ability to skip the fetching of Ktypes during Session-startup**: this is usefull e.g. when the SDK is used behind API-endpoints and initialized during each endpoint-call. Since the KTypes are fetched anytime the DSMS-object is initialized, this might lead to unnecessary latency of the endpoint response. This can be now supressed by related env-variables of Config-kwargs during the session startup.
* **Refetch Ktypes from backend anytime they are needed**: This is usefull, if the DSMS-object is initialized only once during the startup of continuously running app (e.g. the time series plot) and is not re-initialized during the respective API-calls. This will ensure that the latest ktypes are always fetched.
