### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
                   --outdir dist/
 
             - name: Upload distribution artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: release
                   path: dist/
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               name: Download distribution artifact
               with:
                   name: release


### PR DESCRIPTION
upload-artifact@v3 and download-artifact@v3 is deprecated and hence automatically resolves into a failed job when used in the github-ci.