### PR TITLE
v3.2.1

### DIFF
--- a/docs/dsms_sdk/tutorials/2_creation.ipynb
+++ b/docs/dsms_sdk/tutorials/2_creation.ipynb
@@ -145,7 +145,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://bue.materials-data.space/knowledge/specimen/specimen123-ff1316ef'"
+       "'https://bue.materials-data.space/knowledge/specimen/specimen123-8a7f158b'"
       ]
      },
      "execution_count": 4,
@@ -176,9 +176,9 @@
       "text/plain": [
        "kitem:\n",
        "  name: Specimen123\n",
-       "  id: ff1316ef-790c-4833-915c-de13c5f3ba91\n",
+       "  id: 8a7f158b-b1c5-4508-84a5-e20fe7191fd0\n",
        "  ktype_id: specimen\n",
-       "  slug: specimen123-ff1316ef\n",
+       "  slug: specimen123-8a7f158b\n",
        "  annotations: []\n",
        "  attachments:\n",
        "  - name: subgraph.ttl\n",
@@ -188,8 +188,8 @@
        "  - user_id: 7f0e5a37-353b-4bbc-b1f1-b6ad575f562d\n",
        "  avatar_exists: false\n",
        "  contacts: []\n",
-       "  created_at: 2025-04-10 10:29:24.395884\n",
-       "  updated_at: 2025-04-10 10:29:24.395884\n",
+       "  created_at: 2025-04-14 12:34:01.852332\n",
+       "  updated_at: 2025-04-14 12:34:01.852332\n",
        "  external_links: []\n",
        "  apps: []\n",
        "  user_groups: []\n",
@@ -277,7 +277,7 @@
     {
      "data": {
       "text/plain": [
-       "UUID('ff1316ef-790c-4833-915c-de13c5f3ba91')"
+       "UUID('8a7f158b-b1c5-4508-84a5-e20fe7191fd0')"
       ]
      },
      "execution_count": 7,
@@ -491,6 +491,33 @@
    ],
    "source": [
     "item.custom_properties.Length.convert_to(\"m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also convert the custom_properties to a flat dict by passing the `flat`-parameter to the `model_dump`-method of the pydantic model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Width': 0.5, 'Length': [0.1, 0.2]}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "item.custom_properties.model_dump(flat=True)"
    ]
   },
   {

--- a/dsms/knowledge/webform.py
+++ b/dsms/knowledge/webform.py
@@ -697,3 +697,41 @@ class KItemCustomPropertiesModel(BaseWebformModel):
     def __repr__(self) -> str:
         """Pretty print the model fields"""
         return str(self)
+
+    # OVERRIDE
+    def model_dump(self, *args, flat: bool = False, **kwargs):
+        """
+        Dump the custom properties model fields into a dictionary format.
+
+        This method converts the model's sections and entries into a dictionary
+        representation. If the `flat` parameter is set to True, it attempts to
+        create a flat dictionary where each entry's label is a key and its value
+        is the corresponding value. If duplicate labels are found, it raises a
+        ValueError. If `flat` is False, the method utilizes the superclass's
+        `model_dump` method for the output.
+
+        Args:
+            *args: Additional arguments for the superclass's `model_dump`.
+            flat (bool): Whether to produce a flat dictionary. Defaults to False.
+            **kwargs: Additional keyword arguments for the superclass's `model_dump`.
+
+        Returns:
+            dict: A dictionary representation of the custom properties model.
+
+        Raises:
+            ValueError: If `flat` is True and duplicate entry labels are found.
+        """
+
+        if flat:
+            dumped = {}
+            for section in self.sections:  # pylint: disable=not-an-iterable
+                for entry in section.entries:
+                    if entry.label in dumped:
+                        raise ValueError(
+                            f"""Flat model_dump is not possible.
+                            Custom properties model has multiple entries for '{entry.label}'"""
+                        )
+                    dumped[entry.label] = entry.value
+        else:
+            dumped = super().model_dump(*args, **kwargs)
+        return dumped


### PR DESCRIPTION
* Add `flat`-flag to `model_dump` method of `KItemCustomPropertiesModel`

With this patch, a user can dump the custom properties to a flat dictionary by using the native `model_dump`-function of the pydantic model.

Example:

```{python}

item.custom_properties.model_dump(flat=True)

```

Example Output:
```{python}
{'Width': 0.5, 'Length': [0.1, 0.2]}
```
